### PR TITLE
feat(ci): add discord webhook notification for failed test runs

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -32,3 +32,13 @@ jobs:
 
             - run: pnpm test
               working-directory: ProjectSourceCode/server
+
+            - name: Send Discord Notification on Failure
+              if: failure()
+              env:
+                DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+              run: |
+                curl -H "Content-Type: application/json" \
+                -X POST \
+                -d "{\"content\": \"🚨 **Build Failed.** The CI tests did not pass on the \`${{ github.ref_name }}\` branch. Please check the Actions tab to review the logs.\"}" \
+                $DISCORD_WEBHOOK


### PR DESCRIPTION
<!-- PR Template-->

## Changes
- Added a new step to `.github/workflows/test-server.yml` to trigger a Discord Webhook.
- The webhook only fires `if: failure()` occurs during the build/test process.
- Connected the workflow to the `DISCORD_WEBHOOK` repository secret.
- Resolves Issue #85.

## Test Plan
Could do a follow up commit that fails to verify the Discord bot successfully posts the failure message in our server.

## Other
